### PR TITLE
feat(android): support multi-mod hook chaining and ImGui CJK text rendering

### DIFF
--- a/Android/library/src/main/cpp/CMakeLists.txt
+++ b/Android/library/src/main/cpp/CMakeLists.txt
@@ -23,8 +23,9 @@ add_compile_options(-Wno-deprecated-declarations)
 # ---- Source files ----
 set(MODMANAGER_SOURCES
     core/dobby_hook.cpp
-        core/jni_helper.c
-        core/misc.c
+    core/hook_broker.cpp
+    core/jni_helper.c
+    core/misc.c
 )
 
 set(MONODROID_SOURCES

--- a/Android/library/src/main/cpp/core/dobby_hook.cpp
+++ b/Android/library/src/main/cpp/core/dobby_hook.cpp
@@ -4,6 +4,8 @@
 
 #include <dobby.h>
 
+#include "hook_broker.h"
+
 #define LOG_TAG "StArray.ModManager.Dobby"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
@@ -23,9 +25,13 @@ extern "C" {
  * @return 0 成功，非 0 失败
  */
 int modmanager_dobby_hook(void *address, void *replace_func, void **origin_func) {
-    LOGI("DobbyHook at %p, replace=%p", address, replace_func);
-    int ret = DobbyHook(address, (dobby_dummy_func_t)replace_func, (dobby_dummy_func_t *)origin_func);
-    if (ret != 0) LOGE("DobbyHook failed at %p, ret=%d", address, ret);
+    LOGI("HookBroker install at %p, replace=%p", address, replace_func);
+    int ret = modmanager_hook_broker_install(
+        "ModManager.ManagedDobby",
+        address,
+        replace_func,
+        origin_func);
+    if (ret != 0) LOGE("HookBroker install failed at %p, ret=%d", address, ret);
     return ret;
 }
 
@@ -46,8 +52,11 @@ int modmanager_dobby_instrument(void *address, void *pre_handler) {
  * @return 0 成功
  */
 int modmanager_dobby_destroy(void *address) {
-    LOGI("DobbyDestroy at %p", address);
-    return DobbyDestroy(address);
+    // A chain patches the previous detour head, so removing the root target
+    // would leave the remaining layers pointing into invalid trampolines.
+    // Hook layers are therefore process-lifetime once installed.
+    LOGE("DobbyDestroy rejected: HookBroker chains are process-lifetime (address=%p)", address);
+    return -2;
 }
 
 /**

--- a/Android/library/src/main/cpp/core/hook_broker.cpp
+++ b/Android/library/src/main/cpp/core/hook_broker.cpp
@@ -1,0 +1,274 @@
+#include "hook_broker.h"
+
+#include <android/log.h>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <dobby.h>
+
+#define LOG_TAG "StArray.HookBroker"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+namespace {
+
+struct HookLayer {
+    std::string owner;
+    void *replacement = nullptr;
+    void *continuation = nullptr;
+};
+
+struct HookChain {
+    void *target = nullptr;
+    void *head = nullptr;
+    void *root_original = nullptr;
+    std::vector<HookLayer> layers;
+};
+
+std::mutex g_hook_broker_lock;
+std::vector<HookChain> g_hook_chains;
+thread_local std::string g_hook_broker_last_error;
+
+HookChain *find_chain(void *target) {
+    for (auto &chain : g_hook_chains) {
+        if (chain.target == target)
+            return &chain;
+    }
+    return nullptr;
+}
+
+const HookLayer *find_layer(const HookChain &chain, void *replacement) {
+    for (const auto &layer : chain.layers) {
+        if (layer.replacement == replacement)
+            return &layer;
+    }
+    return nullptr;
+}
+
+bool replacement_is_used_by_other_chain(void *target, void *replacement) {
+    for (const auto &chain : g_hook_chains) {
+        if (chain.target == target)
+            continue;
+        if (find_layer(chain, replacement) != nullptr)
+            return true;
+    }
+    return false;
+}
+
+bool validate_aarch64_patch_point(
+    void *function,
+    void *replacement,
+    std::string &error) {
+#if defined(__aarch64__)
+    if (function == nullptr || replacement == nullptr) {
+        error = "patch point and replacement are required";
+        return false;
+    }
+
+    // Dobby uses a 12-byte or 16-byte AArch64 trampoline depending on the
+    // distance between the patch point and replacement.
+    const uintptr_t function_address = reinterpret_cast<uintptr_t>(function);
+    const uintptr_t replacement_address = reinterpret_cast<uintptr_t>(replacement);
+    const uint64_t distance = function_address >= replacement_address
+        ? static_cast<uint64_t>(function_address - replacement_address)
+        : static_cast<uint64_t>(replacement_address - function_address);
+    const size_t patch_instruction_count = distance < (uint64_t{1} << 32u)
+        ? 3u
+        : 4u;
+
+    uint32_t instructions[4]{};
+    std::memcpy(instructions, function, sizeof(instructions));
+    const uint32_t first = instructions[0];
+    const uint32_t second = instructions[1];
+
+    const auto is_direct_branch = [](uint32_t instruction) {
+        return (instruction & 0xFC000000u) == 0x14000000u;
+    };
+    const auto is_register_branch = [](uint32_t instruction) {
+        return (instruction & 0xFFFFFC1Fu) == 0xD61F0000u;
+    };
+    const auto is_return = [](uint32_t instruction) {
+        return (instruction & 0xFFFFFC1Fu) == 0xD65F0000u;
+    };
+    const auto is_breakpoint = [](uint32_t instruction) {
+        return (instruction & 0xFFE0001Fu) == 0xD4200000u;
+    };
+    const auto is_bti = [](uint32_t instruction) {
+        return instruction == 0xD503241Fu ||
+               instruction == 0xD503245Fu ||
+               instruction == 0xD503249Fu ||
+               instruction == 0xD50324DFu;
+    };
+    const auto is_ldr_literal_x = [](uint32_t instruction) {
+        return (instruction & 0xFF000000u) == 0x58000000u;
+    };
+
+    const bool literal_register_branch =
+        is_ldr_literal_x(first) &&
+        is_register_branch(second) &&
+        (first & 0x1Fu) == ((second >> 5u) & 0x1Fu);
+
+    if (is_direct_branch(first) ||
+        literal_register_branch ||
+        (is_bti(first) && is_direct_branch(second))) {
+        std::ostringstream message;
+        message << "patch point already contains an unmanaged branch first=0x"
+                << std::hex << first << " second=0x" << second;
+        error = message.str();
+        return false;
+    }
+
+    for (size_t index = 0; index + 1u < patch_instruction_count; ++index) {
+        const uint32_t instruction = instructions[index];
+        if (is_direct_branch(instruction) ||
+            is_register_branch(instruction) ||
+            is_return(instruction) ||
+            is_breakpoint(instruction)) {
+            std::ostringstream message;
+            message << "patch point is shorter than Dobby's "
+                    << std::dec << (patch_instruction_count * sizeof(uint32_t))
+                    << "-byte trampoline; terminal instruction index="
+                    << index << " value=0x" << std::hex << instruction;
+            error = message.str();
+            return false;
+        }
+    }
+#else
+    (void)function;
+    (void)replacement;
+#endif
+    error.clear();
+    return true;
+}
+
+void set_error(std::string message) {
+    g_hook_broker_last_error = std::move(message);
+    LOGE("%s", g_hook_broker_last_error.c_str());
+}
+
+} // namespace
+
+extern "C" {
+
+int modmanager_hook_broker_install(
+    const char *owner,
+    void *target,
+    void *replacement,
+    void **continuation_out) {
+    if (target == nullptr || replacement == nullptr || continuation_out == nullptr) {
+        set_error("install rejected: target, replacement and continuation_out are required");
+        return -1;
+    }
+    if (target == replacement) {
+        set_error("install rejected: target equals replacement");
+        return -2;
+    }
+
+    const std::string owner_name = owner == nullptr || owner[0] == '\0'
+        ? "anonymous"
+        : owner;
+
+    std::lock_guard<std::mutex> guard(g_hook_broker_lock);
+    auto *chain = find_chain(target);
+    if (chain != nullptr) {
+        if (const auto *existing = find_layer(*chain, replacement); existing != nullptr) {
+            *continuation_out = existing->continuation;
+            g_hook_broker_last_error.clear();
+            LOGI("reuse owner=%s target=%p replacement=%p continuation=%p layers=%zu",
+                 owner_name.c_str(),
+                 target,
+                 replacement,
+                 existing->continuation,
+                 chain->layers.size());
+            return 0;
+        }
+    }
+
+    if (replacement_is_used_by_other_chain(target, replacement)) {
+        set_error("install rejected: replacement is already bound to another target");
+        return -3;
+    }
+
+    void *patch_point = chain == nullptr ? target : chain->head;
+    std::string entry_error;
+    if (!validate_aarch64_patch_point(patch_point, replacement, entry_error)) {
+        set_error("install rejected for owner=" + owner_name + ": " + entry_error);
+        return -4;
+    }
+
+    // Reserve all vector storage before changing executable code. Dobby has
+    // already modified the process once it returns successfully.
+    HookChain prepared_chain;
+    if (chain == nullptr) {
+        g_hook_chains.reserve(g_hook_chains.size() + 1);
+        prepared_chain.target = target;
+        prepared_chain.layers.reserve(1);
+    } else {
+        chain->layers.reserve(chain->layers.size() + 1);
+    }
+    HookLayer prepared_layer;
+    prepared_layer.owner = owner_name;
+    prepared_layer.replacement = replacement;
+
+    void *continuation = nullptr;
+    const int rc = DobbyHook(
+        patch_point,
+        reinterpret_cast<dobby_dummy_func_t>(replacement),
+        reinterpret_cast<dobby_dummy_func_t *>(&continuation));
+    if (rc != 0 || continuation == nullptr) {
+        std::ostringstream message;
+        message << "DobbyHook failed owner=" << owner_name
+                << " target=" << target
+                << " patchPoint=" << patch_point
+                << " replacement=" << replacement
+                << " rc=" << rc
+                << " continuation=" << continuation;
+        set_error(message.str());
+        return rc != 0 ? rc : -5;
+    }
+
+    if (chain == nullptr) {
+        prepared_chain.head = replacement;
+        prepared_chain.root_original = continuation;
+        g_hook_chains.push_back(std::move(prepared_chain));
+        chain = &g_hook_chains.back();
+    } else {
+        chain->head = replacement;
+    }
+
+    prepared_layer.continuation = continuation;
+    chain->layers.push_back(std::move(prepared_layer));
+    *continuation_out = continuation;
+    g_hook_broker_last_error.clear();
+
+    LOGI("installed owner=%s target=%p patchPoint=%p replacement=%p continuation=%p layers=%zu",
+         owner_name.c_str(),
+         target,
+         patch_point,
+         replacement,
+         continuation,
+         chain->layers.size());
+    return 0;
+}
+
+int modmanager_hook_broker_get_chain_count(void) {
+    std::lock_guard<std::mutex> guard(g_hook_broker_lock);
+    return static_cast<int>(g_hook_chains.size());
+}
+
+int modmanager_hook_broker_get_layer_count(void *target) {
+    std::lock_guard<std::mutex> guard(g_hook_broker_lock);
+    const auto *chain = find_chain(target);
+    return chain == nullptr ? 0 : static_cast<int>(chain->layers.size());
+}
+
+const char *modmanager_hook_broker_get_last_error(void) {
+    return g_hook_broker_last_error.c_str();
+}
+
+} // extern "C"

--- a/Android/library/src/main/cpp/core/hook_broker.h
+++ b/Android/library/src/main/cpp/core/hook_broker.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int modmanager_hook_broker_install(
+    const char *owner,
+    void *target,
+    void *replacement,
+    void **continuation_out);
+
+int modmanager_hook_broker_get_chain_count(void);
+int modmanager_hook_broker_get_layer_count(void *target);
+const char *modmanager_hook_broker_get_last_error(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/StArray.ModManager.Analyzer/HookGenerator.cs
+++ b/StArray.ModManager.Analyzer/HookGenerator.cs
@@ -202,6 +202,7 @@ public class HookGenerator : IIncrementalGenerator
                 sb.AppendLine();
                 sb.AppendLine($"        private static bool Install_{sf}()");
                 sb.AppendLine("        {");
+                sb.AppendLine($"            if (_{sf}_origPtr != nint.Zero) return true;");
                 if (h.AttrType == "NativeHook")
                 {
                     bool isRva = h.CtorArgs.Length == 2 && h.CtorArgs[0].StartsWith("\"") && !h.CtorArgs[1].StartsWith("\"");
@@ -223,7 +224,6 @@ public class HookGenerator : IIncrementalGenerator
                         sb.AppendLine($"            var t = global::StArray.ModManager.Runtime.HookHelper.GetFunction({l}, {s});");
                     }
                     sb.AppendLine($"            if (t == nint.Zero) return false;");
-                    sb.AppendLine($"            _{sf}_origPtr = t;");
                     if (h.HasUnmanagedCallersOnly)
                         sb.AppendLine($"            var d = typeof({h.ContainingType}).GetMethod(\"{h.MethodName}\", global::System.Reflection.BindingFlags.Static | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic)!.MethodHandle.GetFunctionPointer();");
                     else
@@ -232,7 +232,13 @@ public class HookGenerator : IIncrementalGenerator
                         sb.AppendLine($"            var d = global::System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(_{sf}_wrap);");
                     }
                     sb.AppendLine($"            var o = global::StArray.ModManager.Runtime.HookHelper.Hook(t, d);");
-                    sb.AppendLine($"            if (o == nint.Zero) return false;");
+                    sb.AppendLine($"            if (o == nint.Zero)");
+                    sb.AppendLine("            {");
+                    if (!h.HasUnmanagedCallersOnly)
+                        sb.AppendLine($"                _{sf}_wrap = null;");
+                    sb.AppendLine("                return false;");
+                    sb.AppendLine("            }");
+                    sb.AppendLine($"            _{sf}_origPtr = t;");
                     sb.AppendLine($"            _{sf}_orig = global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<_{sf}Delegate>(o);");
                     sb.AppendLine("            return true;");
                 }
@@ -275,7 +281,6 @@ public class HookGenerator : IIncrementalGenerator
                         sb.AppendLine($"            var method = cls.GetMethod({m}, {pc});");
                     sb.AppendLine($"            if (method == null) return false;");
                     sb.AppendLine($"            var t = method.FunctionPtr;");
-                    sb.AppendLine($"            _{sf}_origPtr = t;");
                     if (h.HasUnmanagedCallersOnly)
                         sb.AppendLine($"            var d = typeof({h.ContainingType}).GetMethod(\"{h.MethodName}\", global::System.Reflection.BindingFlags.Static | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic)!.MethodHandle.GetFunctionPointer();");
                     else
@@ -284,7 +289,13 @@ public class HookGenerator : IIncrementalGenerator
                         sb.AppendLine($"            var d = global::System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(_{sf}_wrap);");
                     }
                     sb.AppendLine($"            var o = global::StArray.ModManager.Runtime.HookHelper.Hook(t, d);");
-                    sb.AppendLine($"            if (o == nint.Zero) return false;");
+                    sb.AppendLine($"            if (o == nint.Zero)");
+                    sb.AppendLine("            {");
+                    if (!h.HasUnmanagedCallersOnly)
+                        sb.AppendLine($"                _{sf}_wrap = null;");
+                    sb.AppendLine("                return false;");
+                    sb.AppendLine("            }");
+                    sb.AppendLine($"            _{sf}_origPtr = t;");
                     sb.AppendLine($"            _{sf}_orig = global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<_{sf}Delegate>(o);");
                     sb.AppendLine("            return true;");
                 }
@@ -317,11 +328,13 @@ public class HookGenerator : IIncrementalGenerator
                 var sf = Sanitize(h.MethodName);
                 sb.AppendLine($"            if (_{sf}_origPtr != nint.Zero)");
                 sb.AppendLine($"            {{");
-                sb.AppendLine($"                global::StArray.ModManager.Runtime.HookHelper.Unhook(_{sf}_origPtr);");
-                sb.AppendLine($"                _{sf}_origPtr = nint.Zero;");
-                sb.AppendLine($"                _{sf}_orig = null;");
+                sb.AppendLine($"                if (global::StArray.ModManager.Runtime.HookHelper.Unhook(_{sf}_origPtr))");
+                sb.AppendLine("                {");
+                sb.AppendLine($"                    _{sf}_origPtr = nint.Zero;");
+                sb.AppendLine($"                    _{sf}_orig = null;");
                 if (!h.HasUnmanagedCallersOnly)
-                    sb.AppendLine($"                _{sf}_wrap = null;");
+                    sb.AppendLine($"                    _{sf}_wrap = null;");
+                sb.AppendLine("                }");
                 sb.AppendLine($"            }}");
             }
             sb.AppendLine("        }");

--- a/StArray.ModManager.Analyzer/HookGenerator.cs
+++ b/StArray.ModManager.Analyzer/HookGenerator.cs
@@ -193,16 +193,60 @@ public class HookGenerator : IIncrementalGenerator
                 sb.AppendLine($"        private delegate {rt} _{sf}Delegate({pd});");
                 sb.AppendLine($"        private static nint _{sf}_origPtr;");
                 sb.AppendLine($"        private static _{sf}Delegate? _{sf}_orig;");
+                sb.AppendLine($"        private static int _{sf}_enabled;");
 
-                // ── 持久引用（防止 delegate 被 GC；[UnmanagedCallersOnly] 不需要）──
-                if (!h.HasUnmanagedCallersOnly)
-                    sb.AppendLine($"        private static _{sf}Delegate? _{sf}_wrap;");
+                // The native hook can outlive a Mod on Android. Keep the
+                // dispatch delegate alive and turn an uninstall into a
+                // forwarding operation when the provider cannot unhook.
+                sb.AppendLine($"        private static _{sf}Delegate? _{sf}_wrap;");
+                if (h.HasUnmanagedCallersOnly)
+                    sb.AppendLine($"        private static _{sf}Delegate? _{sf}_user;");
+
+                // ── Dispatch ──
+                sb.AppendLine();
+                sb.AppendLine($"        private static {rt} _{sf}_Dispatch({pd})");
+                sb.AppendLine("        {");
+                sb.AppendLine($"            if (global::System.Threading.Volatile.Read(ref _{sf}_enabled) == 0)");
+                sb.AppendLine("            {");
+                if (rt == "void")
+                {
+                    sb.AppendLine($"                _{sf}_orig?.Invoke({pn});");
+                    sb.AppendLine("                return;");
+                }
+                else
+                {
+                    sb.AppendLine($"                if (_{sf}_orig != null) return _{sf}_orig({pn});");
+                    sb.AppendLine("                return default;");
+                }
+                sb.AppendLine("            }");
+                if (h.HasUnmanagedCallersOnly)
+                {
+                    if (rt == "void")
+                        sb.AppendLine($"            _{sf}_user?.Invoke({pn});");
+                    else
+                        sb.AppendLine($"            if (_{sf}_user != null) return _{sf}_user({pn});");
+                    if (rt != "void")
+                        sb.AppendLine("            return default;");
+                }
+                else if (rt == "void")
+                {
+                    sb.AppendLine($"            {h.MethodName}({pn});");
+                }
+                else
+                {
+                    sb.AppendLine($"            return {h.MethodName}({pn});");
+                }
+                sb.AppendLine("        }");
 
                 // ── Install ──
                 sb.AppendLine();
                 sb.AppendLine($"        private static bool Install_{sf}()");
                 sb.AppendLine("        {");
-                sb.AppendLine($"            if (_{sf}_origPtr != nint.Zero) return true;");
+                sb.AppendLine($"            if (_{sf}_origPtr != nint.Zero)");
+                sb.AppendLine("            {");
+                sb.AppendLine($"                global::System.Threading.Volatile.Write(ref _{sf}_enabled, 1);");
+                sb.AppendLine("                return true;");
+                sb.AppendLine("            }");
                 if (h.AttrType == "NativeHook")
                 {
                     bool isRva = h.CtorArgs.Length == 2 && h.CtorArgs[0].StartsWith("\"") && !h.CtorArgs[1].StartsWith("\"");
@@ -225,21 +269,24 @@ public class HookGenerator : IIncrementalGenerator
                     }
                     sb.AppendLine($"            if (t == nint.Zero) return false;");
                     if (h.HasUnmanagedCallersOnly)
-                        sb.AppendLine($"            var d = typeof({h.ContainingType}).GetMethod(\"{h.MethodName}\", global::System.Reflection.BindingFlags.Static | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic)!.MethodHandle.GetFunctionPointer();");
-                    else
                     {
-                        sb.AppendLine($"            _{sf}_wrap = {h.MethodName};");
-                        sb.AppendLine($"            var d = global::System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(_{sf}_wrap);");
+                        sb.AppendLine($"            var userMethod = typeof({h.ContainingType}).GetMethod(\"{h.MethodName}\", global::System.Reflection.BindingFlags.Static | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic)!;");
+                        sb.AppendLine("            global::System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(userMethod.MethodHandle);");
+                        sb.AppendLine($"            _{sf}_user = global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<_{sf}Delegate>(userMethod.MethodHandle.GetFunctionPointer());");
                     }
+                    sb.AppendLine($"            _{sf}_wrap = _{sf}_Dispatch;");
+                    sb.AppendLine($"            var d = global::System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(_{sf}_wrap);");
                     sb.AppendLine($"            var o = global::StArray.ModManager.Runtime.HookHelper.Hook(t, d);");
                     sb.AppendLine($"            if (o == nint.Zero)");
                     sb.AppendLine("            {");
-                    if (!h.HasUnmanagedCallersOnly)
-                        sb.AppendLine($"                _{sf}_wrap = null;");
+                    sb.AppendLine($"                _{sf}_wrap = null;");
+                    if (h.HasUnmanagedCallersOnly)
+                        sb.AppendLine($"                _{sf}_user = null;");
                     sb.AppendLine("                return false;");
                     sb.AppendLine("            }");
                     sb.AppendLine($"            _{sf}_origPtr = t;");
                     sb.AppendLine($"            _{sf}_orig = global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<_{sf}Delegate>(o);");
+                    sb.AppendLine($"            global::System.Threading.Volatile.Write(ref _{sf}_enabled, 1);");
                     sb.AppendLine("            return true;");
                 }
                 else // UnmanagedHook
@@ -282,21 +329,24 @@ public class HookGenerator : IIncrementalGenerator
                     sb.AppendLine($"            if (method == null) return false;");
                     sb.AppendLine($"            var t = method.FunctionPtr;");
                     if (h.HasUnmanagedCallersOnly)
-                        sb.AppendLine($"            var d = typeof({h.ContainingType}).GetMethod(\"{h.MethodName}\", global::System.Reflection.BindingFlags.Static | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic)!.MethodHandle.GetFunctionPointer();");
-                    else
                     {
-                        sb.AppendLine($"            _{sf}_wrap = {h.MethodName};");
-                        sb.AppendLine($"            var d = global::System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(_{sf}_wrap);");
+                        sb.AppendLine($"            var userMethod = typeof({h.ContainingType}).GetMethod(\"{h.MethodName}\", global::System.Reflection.BindingFlags.Static | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic)!;");
+                        sb.AppendLine("            global::System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(userMethod.MethodHandle);");
+                        sb.AppendLine($"            _{sf}_user = global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<_{sf}Delegate>(userMethod.MethodHandle.GetFunctionPointer());");
                     }
+                    sb.AppendLine($"            _{sf}_wrap = _{sf}_Dispatch;");
+                    sb.AppendLine($"            var d = global::System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(_{sf}_wrap);");
                     sb.AppendLine($"            var o = global::StArray.ModManager.Runtime.HookHelper.Hook(t, d);");
                     sb.AppendLine($"            if (o == nint.Zero)");
                     sb.AppendLine("            {");
-                    if (!h.HasUnmanagedCallersOnly)
-                        sb.AppendLine($"                _{sf}_wrap = null;");
+                    sb.AppendLine($"                _{sf}_wrap = null;");
+                    if (h.HasUnmanagedCallersOnly)
+                        sb.AppendLine($"                _{sf}_user = null;");
                     sb.AppendLine("                return false;");
                     sb.AppendLine("            }");
                     sb.AppendLine($"            _{sf}_origPtr = t;");
                     sb.AppendLine($"            _{sf}_orig = global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<_{sf}Delegate>(o);");
+                    sb.AppendLine($"            global::System.Threading.Volatile.Write(ref _{sf}_enabled, 1);");
                     sb.AppendLine("            return true;");
                 }
                 sb.AppendLine("        }");
@@ -316,8 +366,17 @@ public class HookGenerator : IIncrementalGenerator
             sb.AppendLine("        public static bool InstallHooks()");
             sb.AppendLine("        {");
             sb.AppendLine("            bool ok = true;");
+            sb.AppendLine("            try");
+            sb.AppendLine("            {");
             foreach (var h in group)
-                sb.AppendLine($"            ok &= Install_{Sanitize(h.MethodName)}();");
+                sb.AppendLine($"                if (!Install_{Sanitize(h.MethodName)}()) ok = false;");
+            sb.AppendLine("            }");
+            sb.AppendLine("            catch");
+            sb.AppendLine("            {");
+            sb.AppendLine("                UninstallHooks();");
+            sb.AppendLine("                throw;");
+            sb.AppendLine("            }");
+            sb.AppendLine("            if (!ok) UninstallHooks();");
             sb.AppendLine("            return ok;");
             sb.AppendLine("        }");
             sb.AppendLine();
@@ -328,12 +387,14 @@ public class HookGenerator : IIncrementalGenerator
                 var sf = Sanitize(h.MethodName);
                 sb.AppendLine($"            if (_{sf}_origPtr != nint.Zero)");
                 sb.AppendLine($"            {{");
+                sb.AppendLine($"                global::System.Threading.Volatile.Write(ref _{sf}_enabled, 0);");
                 sb.AppendLine($"                if (global::StArray.ModManager.Runtime.HookHelper.Unhook(_{sf}_origPtr))");
                 sb.AppendLine("                {");
                 sb.AppendLine($"                    _{sf}_origPtr = nint.Zero;");
                 sb.AppendLine($"                    _{sf}_orig = null;");
-                if (!h.HasUnmanagedCallersOnly)
-                    sb.AppendLine($"                    _{sf}_wrap = null;");
+                sb.AppendLine($"                    _{sf}_wrap = null;");
+                if (h.HasUnmanagedCallersOnly)
+                    sb.AppendLine($"                    _{sf}_user = null;");
                 sb.AppendLine("                }");
                 sb.AppendLine($"            }}");
             }

--- a/StArray.ModManager.Android/Native/Dobby.cs
+++ b/StArray.ModManager.Android/Native/Dobby.cs
@@ -1,95 +1,157 @@
-using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using StArray.ModManager.Manager;
 
 namespace StArray.ModManager.Android.Native;
 
 /// <summary>
-/// Dobby Hook P/Invoke 封装。
-/// 对应 native 端的 <c>core/dobby_hook.cpp</c>，导出 C ABI 函数。
-/// 所有方法通过 <c>[DllImport("modmanager")]</c> 调用 <c>libmodmanager.so</c>。
+/// Dobby P/Invoke wrapper backed by the process-wide native HookBroker.
+/// The broker appends different detours to the same target and returns the
+/// continuation for each layer.
 /// </summary>
 public static class Dobby
 {
     private const string Lib = "modmanager";
+    private static readonly object HookLock = new();
+    private static readonly Dictionary<HookKey, HookRecord> InstalledHooks = new();
+    private static readonly Dictionary<nint, HookRecord> LatestHooks = new();
 
-    // ========================================================================
-    // Native externs
-    // ========================================================================
+    private readonly record struct HookKey(nint Target, nint Detour);
+    private sealed record HookRecord(nint Target, nint Detour, nint Origin, string Owner);
 
-    /// <summary>安装 inline hook。</summary>
-    /// <param name="address">目标函数地址</param>
-    /// <param name="replace">替换函数地址（nint 指向 delegate 或函数指针）</param>
-    /// <param name="origin">[out] 原函数指针（用于调用原逻辑）</param>
-    /// <returns>0 = 成功，非 0 = 失败</returns>
-    [DllImport(Lib, EntryPoint = "modmanager_dobby_hook")]
-    public static extern int Hook(nint address, nint replace, out nint origin);
+    [DllImport(Lib, EntryPoint = "modmanager_hook_broker_install", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int InstallBrokerHook(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string owner,
+        nint address,
+        nint replace,
+        out nint origin);
+
+    /// <summary>安装 inline hook，并返回当前 layer 的 continuation。</summary>
+    public static int Hook(nint address, nint replace, out nint origin)
+        => Hook(address, replace, out origin, "Dobby.Hook");
 
     /// <summary>
-    /// 安装 inline hook — 传入 C# Reflection MethodInfo。
-    /// 方法会被 PrepareMethod 强制 JIT 编译，再取其函数指针作为 replace。
+    /// 安装 inline hook，并记录安装方。
+    /// 同一地址的不同 detour 会由 native HookBroker 追加为新 layer；同一
+    /// detour 的重复注册复用原 continuation。
     /// </summary>
-    /// <param name="address">目标函数地址</param>
-    /// <param name="replaceMethod">C# MethodInfo（需为静态方法）</param>
-    /// <param name="origin">[out] 原函数指针</param>
-    /// <returns>0 = 成功，非 0 = 失败</returns>
+    public static int Hook(nint address, nint replace, out nint origin, string owner)
+    {
+        origin = nint.Zero;
+        if (address == nint.Zero || replace == nint.Zero)
+            return -1;
+
+        lock (HookLock)
+        {
+            var key = new HookKey(address, replace);
+            if (InstalledHooks.TryGetValue(key, out var existing))
+            {
+                origin = existing.Origin;
+                return 0;
+            }
+
+            var normalizedOwner = string.IsNullOrWhiteSpace(owner) ? "unknown" : owner;
+            var result = InstallBrokerHook(normalizedOwner, address, replace, out origin);
+            if (result == 0 && origin != nint.Zero)
+            {
+                var record = new HookRecord(
+                    address,
+                    replace,
+                    origin,
+                    normalizedOwner);
+                InstalledHooks[key] = record;
+                LatestHooks[address] = record;
+            }
+
+            return result;
+        }
+    }
+
+    /// <summary>获取目标地址最近安装的 layer，供诊断使用。</summary>
+    public static bool TryGetInstalledHook(
+        nint address,
+        out string owner,
+        out nint detour,
+        out nint origin)
+    {
+        lock (HookLock)
+        {
+            if (LatestHooks.TryGetValue(address, out var existing))
+            {
+                owner = existing.Owner;
+                detour = existing.Detour;
+                origin = existing.Origin;
+                return true;
+            }
+        }
+
+        owner = string.Empty;
+        detour = nint.Zero;
+        origin = nint.Zero;
+        return false;
+    }
+
+    /// <summary>安装 inline hook，目标替换方法来自托管 MethodInfo。</summary>
     public static int Hook(nint address, MethodInfo replaceMethod, out nint origin)
     {
         if (replaceMethod == null)
         {
-            origin = IntPtr.Zero;
+            origin = nint.Zero;
             return -1;
         }
-        // 强制 JIT 编译该方法
+
         RuntimeHelpers.PrepareMethod(replaceMethod.MethodHandle);
-        nint replacePtr = replaceMethod.MethodHandle.GetFunctionPointer();
-        return Hook(address, replacePtr, out origin);
+        var replacePtr = replaceMethod.MethodHandle.GetFunctionPointer();
+        var owner = replaceMethod.DeclaringType == null
+            ? replaceMethod.Name
+            : replaceMethod.DeclaringType.FullName + "." + replaceMethod.Name;
+        return Hook(address, replacePtr, out origin, owner);
     }
 
-    /// <summary>安装动态指令插桩。</summary>
-    /// <param name="address">目标函数地址</param>
-    /// <param name="preHandler">前置回调函数指针（dobby_instrument_callback_t 签名）</param>
-    /// <returns>0 = 成功</returns>
     [DllImport(Lib, EntryPoint = "modmanager_dobby_instrument")]
     public static extern int Instrument(nint address, nint preHandler);
 
-    /// <summary>移除 hook 并恢复原函数。</summary>
-    /// <param name="address">被 hook 的函数地址</param>
-    /// <returns>0 = 成功</returns>
+    /// <summary>
+    /// 尝试移除 hook。HookBroker 链一旦建立便保持到进程结束，因此该调用
+    /// 对 broker hook 返回失败，不会破坏其他 Mod 的 continuation。
+    /// </summary>
     [DllImport(Lib, EntryPoint = "modmanager_dobby_destroy")]
-    public static extern int Destroy(nint address);
+    private static extern int RemoveHook(nint address);
 
-    /// <summary>按动态库名和符号名解析函数地址。</summary>
-    /// <param name="imageName">动态库名，如 "libil2cpp.so"</param>
-    /// <param name="symbolName">符号名</param>
-    /// <returns>符号地址，失败返回 nint.Zero</returns>
+    public static int Destroy(nint address)
+    {
+        var result = RemoveHook(address);
+        if (result == 0)
+        {
+            lock (HookLock)
+            {
+                foreach (var key in InstalledHooks.Keys
+                             .Where(key => key.Target == address)
+                             .ToArray())
+                    InstalledHooks.Remove(key);
+                LatestHooks.Remove(address);
+            }
+        }
+
+        return result;
+    }
+
     [DllImport(Lib, EntryPoint = "modmanager_dobby_symbol_resolver")]
-    public static extern nint _SymbolResolver(string imageName, string symbolName);
+    public static extern nint SymbolResolver(string imageName, string symbolName);
 
-    /// <summary>内存代码补丁。</summary>
-    /// <param name="address">目标地址</param>
-    /// <param name="buffer">补丁数据</param>
-    /// <param name="bufferSize">补丁数据大小</param>
-    /// <returns>0 = 成功</returns>
+    // Preserve the old helper name used by existing Android code.
+    public static nint _SymbolResolver(string imageName, string symbolName) =>
+        SymbolResolver(imageName, symbolName);
+
     [DllImport(Lib, EntryPoint = "modmanager_dobby_code_patch")]
     public static extern int CodePatch(nint address, byte[] buffer, uint bufferSize);
 
-    /// <summary>获取 Dobby 版本字符串。</summary>
     [DllImport(Lib, EntryPoint = "modmanager_dobby_get_version")]
-    private static extern nint _GetVersionRaw();
-    
-    public static IntPtr SymbolResolver(string imageName, string symbolName){
-        var handle = _SymbolResolver(imageName, symbolName);
-        Logger.Error(nameof(SymbolResolver), $"Resolving {imageName}, {symbolName} = {handle}");
-        return handle;
-    }
+    private static extern nint GetVersionRaw();
 
-    /// <summary>获取 Dobby 版本字符串。</summary>
     public static string GetVersion()
     {
-        var ptr = _GetVersionRaw();
+        var ptr = GetVersionRaw();
         return Marshal.PtrToStringAnsi(ptr) ?? "unknown";
     }
 }

--- a/StArray.ModManager.Android/Native/DobbyHook.cs
+++ b/StArray.ModManager.Android/Native/DobbyHook.cs
@@ -6,9 +6,15 @@ namespace StArray.ModManager.Android.Native;
 
 public class DobbyHook : IHook
 {
+    public bool SupportsRuntimeUnhook => false;
+
     public nint Hook(nint target, nint detour)
+        => Hook(target, detour, null);
+
+    public nint Hook(nint target, nint detour, string? owner)
     {
-        if (Dobby.Hook(target, detour, out var origin) != 0)
+        var hookOwner = string.IsNullOrWhiteSpace(owner) ? nameof(DobbyHook) : owner;
+        if (Dobby.Hook(target, detour, out var origin, hookOwner) != 0)
             return nint.Zero;
         return origin;
     }

--- a/StArray.ModManager/Runtime/HookHelper.cs
+++ b/StArray.ModManager/Runtime/HookHelper.cs
@@ -32,9 +32,9 @@ public static class HookHelper
     public static bool Unhook(nint target)
     {
         var provider = Instance;
-        // No provider means there is no live native hook to keep. This also
-        // lets generated state clear during test or shutdown cleanup.
-        if (provider == null) return true;
+        // Without a provider we cannot know whether the native hook is still
+        // live. Generated hooks must retain their callback in this case.
+        if (provider == null) return false;
         if (!provider.SupportsRuntimeUnhook) return false;
         return provider.Unhook(target);
     }

--- a/StArray.ModManager/Runtime/HookHelper.cs
+++ b/StArray.ModManager/Runtime/HookHelper.cs
@@ -9,6 +9,8 @@ namespace StArray.ModManager.Runtime;
 /// </summary>
 public static class HookHelper
 {
+    private static readonly AsyncLocal<string?> CurrentOwner = new();
+
     /// <summary>当前平台的 Hook 实现（Windows = MinHook，Android = Dobby）</summary>
     public static IHook? Instance { get; set; }
 
@@ -21,15 +23,28 @@ public static class HookHelper
     /// <summary>安装 Hook</summary>
     public static nint Hook(nint target, nint detour)
     {
-        if (Instance == null) return nint.Zero;
-        return Instance.Hook(target, detour);
+        var provider = Instance;
+        if (provider == null) return nint.Zero;
+        return provider.Hook(target, detour, CurrentOwner.Value);
     }
 
     /// <summary>卸载 Hook</summary>
     public static bool Unhook(nint target)
     {
-        if (Instance == null) return false;
-        return Instance.Unhook(target);
+        var provider = Instance;
+        // No provider means there is no live native hook to keep. This also
+        // lets generated state clear during test or shutdown cleanup.
+        if (provider == null) return true;
+        if (!provider.SupportsRuntimeUnhook) return false;
+        return provider.Unhook(target);
+    }
+
+    /// <summary>为当前 Mod 的 hook 安装设置诊断 owner。</summary>
+    internal static IDisposable EnterOwnerScope(string owner)
+    {
+        var previous = CurrentOwner.Value;
+        CurrentOwner.Value = owner;
+        return new OwnerScope(previous);
     }
 
     /// <summary>获取库导出函数地址</summary>
@@ -116,5 +131,17 @@ public static class HookHelper
         }
 
         return nint.Zero;
+    }
+
+    private sealed class OwnerScope(string? previous) : IDisposable
+    {
+        private readonly string? _previous = previous;
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                CurrentOwner.Value = _previous;
+        }
     }
 }

--- a/StArray.ModManager/Runtime/IHook.cs
+++ b/StArray.ModManager/Runtime/IHook.cs
@@ -5,8 +5,15 @@ namespace StArray.ModManager.Runtime;
 /// </summary>
 public interface IHook
 {
+    /// <summary>是否可以在进程运行期间安全移除已安装的 hook。</summary>
+    bool SupportsRuntimeUnhook => true;
+
     /// <summary>安装 hook，将 target 重定向到 detour，返回原始函数指针</summary>
     nint Hook(nint target, nint detour);
+
+    /// <summary>安装带 owner 诊断信息的 hook；旧 provider 默认忽略 owner。</summary>
+    nint Hook(nint target, nint detour, string? owner)
+        => Hook(target, detour);
 
     /// <summary>卸载 target 上的 hook</summary>
     bool Unhook(nint target);

--- a/StArray.ModManager/Runtime/ModLoader.cs
+++ b/StArray.ModManager/Runtime/ModLoader.cs
@@ -188,7 +188,8 @@ public class ModLoader
                 {
                     var plugin = (IModPlugin)Activator.CreateInstance(pluginType)!;
                     mod.PluginInstance = plugin;
-                    plugin.OnLoad();
+                    using (HookHelper.EnterOwnerScope(mod.Id))
+                        plugin.OnLoad();
 
                     if (plugin is IModSettings s)
                         ModManagerUI.LoadSettings(mod, s);
@@ -217,7 +218,11 @@ public class ModLoader
     {
         if (mod.LoadState != ModLoadState.Loaded) return;
 
-        mod.PluginInstance?.OnUnload();
+        if (mod.PluginInstance != null)
+        {
+            using (HookHelper.EnterOwnerScope(mod.Id))
+                mod.PluginInstance.OnUnload();
+        }
         mod.PluginInstance = null;
         mod.IsEnabled = false;
         mod.LoadState = ModLoadState.NotLoaded;

--- a/StArray.ModManager/UI/IImGuiRenderer.cs
+++ b/StArray.ModManager/UI/IImGuiRenderer.cs
@@ -29,19 +29,306 @@ public interface IImGuiRenderer
         io.ConfigFlags |= ImGuiConfigFlags.NavEnableKeyboard | ImGuiConfigFlags.DockingEnable;
         LoadIconFont(io);
         LoadEmbeddedFont(io);
+        if (OperatingSystem.IsAndroid())
+            LoadAndroidFallbackFonts(io);
         // 注意：AddFontFromMemoryTTF 只存指针，Build() 时才真正读取数据
-        io.Fonts.Build();
-        // Build() 之后才能安全释放字体内存
-        FreeFontMemory();
+        try
+        {
+            io.Fonts.Build();
+        }
+        finally
+        {
+            // Build() 之后才能安全释放字体和 range 内存。
+            FreeFontMemory();
+        }
     }
 
     private static nint _fontPtr1, _fontPtr2, _glyphRangesPtr;
+    private static readonly List<nint> _glyphRangePtrs = [];
+
+    private static readonly (string[] Names, ushort[] Ranges)[] AndroidFallbackFonts =
+    [
+        // European languages and common mathematical/symbol blocks.
+        (
+            ["NotoSans-Regular.ttf", "NotoSansDisplay-Regular.ttf"],
+            [
+                0x0020, 0x024F, 0x0250, 0x02AF, 0x02B0, 0x02FF,
+                0x0300, 0x036F, 0x0370, 0x03FF, 0x0400, 0x052F,
+                0x1AB0, 0x1AFF, 0x1C80, 0x1C8F, 0x1CD0, 0x1CFF,
+                0x1DC0, 0x1DFF, 0x1E00, 0x1EFF, 0x1F00, 0x1FFF,
+                0x2000, 0x206F,
+                0x2070, 0x209F, 0x20A0, 0x20CF, 0x2100, 0x214F,
+                0x2150, 0x218F, 0x2190, 0x21FF, 0x2200, 0x22FF,
+                0x2300, 0x23FF, 0x2460, 0x24FF, 0x2500, 0x25FF,
+                0x2600, 0x26FF, 0x2700, 0x27BF, 0x27C0, 0x27FF,
+                0x2900, 0x297F, 0x2980, 0x29FF, 0x2A00, 0x2AFF,
+                0x2B00, 0x2BFF, 0x2C60, 0x2C7F, 0x2DE0, 0x2DFF,
+                0xA640, 0xA69F, 0xA720, 0xA7FF, 0xAB30, 0xAB6F, 0
+            ]
+        ),
+        // Symbols fonts cover arrows, technical symbols and BMP dingbats.
+        (
+            [
+                "NotoSansSymbols2-Regular.ttf",
+                "NotoSansSymbols2-Regular-Subsetted.ttf",
+                "NotoSansSymbols-Regular.ttf",
+                "NotoSansSymbols-Regular-Subsetted.ttf"
+            ],
+            [
+                0x2000, 0x27FF, 0x2900, 0x2BFF, 0xFE00, 0xFE0F, 0
+            ]
+        ),
+        (
+            ["NotoSansMath-Regular.ttf"],
+            [0x2000, 0x206F, 0x2190, 0x21FF, 0x2200, 0x22FF,
+             0x27C0, 0x27EF, 0x2980, 0x29FF, 0x2A00, 0x2AFF, 0]
+        ),
+        // Arabic and Hebrew families are separate on Android.
+        (
+            [
+                "NotoSansArabic-Regular.ttf",
+                "NotoSansArabicUI-Regular.ttf",
+                "NotoNaskhArabic-Regular.ttf"
+            ],
+            [
+                0x0600, 0x06FF, 0x0700, 0x074F, 0x0750, 0x077F,
+                0x0870, 0x089F, 0x08A0, 0x08FF, 0xFB50, 0xFDFF,
+                0xFE70, 0xFEFF, 0
+            ]
+        ),
+        (
+            ["NotoSansHebrew-Regular.ttf", "NotoSansHebrewUI-Regular.ttf"],
+            [0x0590, 0x05FF, 0xFB1D, 0xFB4F, 0]
+        ),
+        (
+            ["NotoSansArmenian-Regular.ttf", "NotoSansArmenianUI-Regular.ttf"],
+            [0x0530, 0x058F, 0xFB13, 0xFB17, 0]
+        ),
+        (
+            ["NotoSansGeorgian-Regular.ttf", "NotoSansGeorgianUI-Regular.ttf"],
+            [0x10A0, 0x10FF, 0x1C90, 0x1CBF, 0x2D00, 0x2D2F, 0]
+        ),
+        // Indic scripts.
+        (
+            ["NotoSansDevanagari-Regular.ttf", "NotoSansDevanagariUI-Regular.ttf"],
+            [0x0900, 0x097F, 0x1CD0, 0x1CFF, 0xA8E0, 0xA8FF, 0]
+        ),
+        (
+            ["NotoSansBengali-Regular.ttf", "NotoSansBengaliUI-Regular.ttf"],
+            [0x0980, 0x09FF, 0]
+        ),
+        (
+            ["NotoSansGurmukhi-Regular.ttf", "NotoSansGurmukhiUI-Regular.ttf"],
+            [0x0A00, 0x0A7F, 0]
+        ),
+        (
+            ["NotoSansGujarati-Regular.ttf", "NotoSansGujaratiUI-Regular.ttf"],
+            [0x0A80, 0x0AFF, 0]
+        ),
+        (
+            [
+                "NotoSansOriya-Regular.ttf",
+                "NotoSansOdia-Regular.ttf",
+                "NotoSansOriyaUI-Regular.ttf",
+                "NotoSansOdiaUI-Regular.ttf"
+            ],
+            [0x0B00, 0x0B7F, 0]
+        ),
+        (
+            ["NotoSansTamil-Regular.ttf", "NotoSansTamilUI-Regular.ttf"],
+            [0x0B80, 0x0BFF, 0]
+        ),
+        (
+            ["NotoSansTelugu-Regular.ttf", "NotoSansTeluguUI-Regular.ttf"],
+            [0x0C00, 0x0C7F, 0]
+        ),
+        (
+            ["NotoSansKannada-Regular.ttf", "NotoSansKannadaUI-Regular.ttf"],
+            [0x0C80, 0x0CFF, 0]
+        ),
+        (
+            ["NotoSansMalayalam-Regular.ttf", "NotoSansMalayalamUI-Regular.ttf"],
+            [0x0D00, 0x0D7F, 0]
+        ),
+        (
+            ["NotoSansSinhala-Regular.ttf", "NotoSansSinhalaUI-Regular.ttf"],
+            [0x0D80, 0x0DFF, 0]
+        ),
+        // Southeast Asian and other BMP scripts.
+        (
+            ["NotoSansThai-Regular.ttf", "NotoSansThaiLooped-Regular.ttf"],
+            [0x0E00, 0x0E7F, 0]
+        ),
+        (
+            ["NotoSansLao-Regular.ttf"],
+            [0x0E80, 0x0EFF, 0]
+        ),
+        (
+            ["NotoSansTibetan-Regular.ttf"],
+            [0x0F00, 0x0FFF, 0]
+        ),
+        (
+            ["NotoSansMyanmar-Regular.ttf"],
+            [0x1000, 0x109F, 0xAA60, 0xAA7F, 0xA9E0, 0xA9FF, 0]
+        ),
+        (
+            ["NotoSansEthiopic-Regular.ttf"],
+            [0x1200, 0x137F, 0x1380, 0x139F, 0x2D80, 0x2DDF, 0xAB00, 0xAB2F, 0]
+        ),
+        (
+            ["NotoSansMongolian-Regular.ttf"],
+            [0x1800, 0x18AF, 0]
+        ),
+        (
+            ["NotoSansKhmer-Regular.ttf"],
+            [0x1780, 0x17FF, 0x19E0, 0x19FF, 0]
+        ),
+        (
+            ["NotoSansCherokee-Regular.ttf"],
+            [0x13A0, 0x13FF, 0xAB70, 0xABBF, 0]
+        ),
+        (
+            ["NotoSansCanadianAboriginal-Regular.ttf"],
+            [0x1400, 0x167F, 0]
+        ),
+        (
+            ["NotoSansSyriac-Regular.ttf"],
+            [0x0700, 0x074F, 0]
+        ),
+        (
+            ["NotoSansSamaritan-Regular.ttf"],
+            [0x0800, 0x083F, 0]
+        ),
+        (
+            ["NotoSansMandaic-Regular.ttf"],
+            [0x0840, 0x085F, 0]
+        ),
+        (
+            ["NotoSansThaana-Regular.ttf"],
+            [0x0780, 0x07BF, 0]
+        ),
+        (
+            ["NotoSansNKo-Regular.ttf"],
+            [0x07C0, 0x07FF, 0]
+        ),
+        (
+            ["NotoSansTifinagh-Regular.ttf"],
+            [0x2D30, 0x2D7F, 0]
+        ),
+        (
+            ["NotoSansGlagolitic-Regular.ttf"],
+            [0x2C00, 0x2C5F, 0]
+        ),
+        (
+            ["NotoSansCoptic-Regular.ttf"],
+            [0x2C80, 0x2CFF, 0]
+        ),
+        (
+            ["NotoSansLisu-Regular.ttf"],
+            [0xA4D0, 0xA4FF, 0]
+        ),
+        (
+            ["NotoSansVai-Regular.ttf"],
+            [0xA500, 0xA63F, 0]
+        ),
+        (
+            ["NotoSansBamum-Regular.ttf"],
+            [0xA6A0, 0xA6FF, 0]
+        ),
+        (
+            ["NotoSansSaurashtra-Regular.ttf"],
+            [0xA880, 0xA8DF, 0]
+        ),
+        (
+            ["NotoSansKayahLi-Regular.ttf"],
+            [0xA900, 0xA92F, 0]
+        ),
+        (
+            ["NotoSansRejang-Regular.ttf"],
+            [0xA930, 0xA95F, 0]
+        ),
+        (
+            ["NotoSansJavanese-Regular.ttf"],
+            [0xA980, 0xA9DF, 0]
+        ),
+        (
+            ["NotoSansCham-Regular.ttf"],
+            [0xAA00, 0xAA5F, 0]
+        ),
+        (
+            ["NotoSansTaiViet-Regular.ttf"],
+            [0xAA80, 0xAADF, 0]
+        ),
+        (
+            ["NotoSansMeeteiMayek-Regular.ttf"],
+            [0xABC0, 0xABFF, 0]
+        ),
+        (
+            ["NotoSansOlChiki-Regular.ttf"],
+            [0x1C50, 0x1C7F, 0]
+        ),
+        (
+            ["NotoSansBuginese-Regular.ttf"],
+            [0x1A00, 0x1A1F, 0]
+        ),
+        (
+            ["NotoSansNewTaiLue-Regular.ttf"],
+            [0x1980, 0x19DF, 0]
+        ),
+        (
+            ["NotoSansTaiTham-Regular.ttf"],
+            [0x1A20, 0x1AAF, 0]
+        ),
+        (
+            ["NotoSansBalinese-Regular.ttf"],
+            [0x1B00, 0x1B7F, 0]
+        ),
+        (
+            ["NotoSansSundanese-Regular.ttf"],
+            [0x1B80, 0x1BBF, 0]
+        ),
+        (
+            ["NotoSansBatak-Regular.ttf"],
+            [0x1BC0, 0x1BFF, 0]
+        ),
+        (
+            ["NotoSansLepcha-Regular.ttf"],
+            [0x1C00, 0x1C4F, 0]
+        )
+    ];
 
     private static void FreeFontMemory()
     {
         if (_fontPtr1 != 0) { Marshal.FreeHGlobal(_fontPtr1); _fontPtr1 = 0; }
         if (_fontPtr2 != 0) { Marshal.FreeHGlobal(_fontPtr2); _fontPtr2 = 0; }
-        if (_glyphRangesPtr != 0) { Marshal.FreeHGlobal(_glyphRangesPtr); _glyphRangesPtr = 0; }
+        foreach (var ptr in _glyphRangePtrs)
+            if (ptr != 0) Marshal.FreeHGlobal(ptr);
+        _glyphRangePtrs.Clear();
+        _glyphRangesPtr = 0;
+    }
+
+    private static unsafe nint CopyGlyphRanges(ushort[] glyphRanges)
+    {
+        var bytes = checked(glyphRanges.Length * sizeof(ushort));
+        var ptr = Marshal.AllocHGlobal(bytes);
+        try
+        {
+            fixed (ushort* ranges = glyphRanges)
+            {
+                Buffer.MemoryCopy(
+                    ranges,
+                    (void*)ptr,
+                    bytes,
+                    bytes);
+            }
+            _glyphRangePtrs.Add(ptr);
+            return ptr;
+        }
+        catch
+        {
+            Marshal.FreeHGlobal(ptr);
+            throw;
+        }
     }
 
     private static unsafe void LoadEmbeddedFont(ImGuiIOPtr io)
@@ -61,41 +348,50 @@ public interface IImGuiRenderer
             // Merge the CJK font into the icon font. The range is kept in unmanaged
             // memory until Build() because ImGui reads it while building the atlas.
             var cfg = ImGuiNative.ImFontConfig_ImFontConfig();
-            cfg->MergeMode = 1;
-            cfg->FontDataOwnedByAtlas = 0; // 自己管理内存，Build() 后释放
-
-            ushort[] glyphRanges =
-            [
-                0x0020, 0x00FF, // Basic Latin and Latin-1 Supplement
-                0x1100, 0x11FF, // Hangul Jamo
-                0x2000, 0x206F, // General Punctuation
-                0x2E80, 0x2FFF, // CJK radicals and ideographs
-                0x3000, 0x30FF, // CJK punctuation, Hiragana, Katakana
-                0x3100, 0x31FF, // Bopomofo and Hangul compatibility Jamo
-                0x3200, 0x33FF, // Enclosed CJK and compatibility characters
-                0x3400, 0x4DBF, // CJK Unified Ideographs Extension A
-                0x4E00, 0x9FFF, // CJK Unified Ideographs
-                0xA960, 0xA97F, // Hangul Jamo Extended-A
-                0xAC00, 0xD7A3, // Hangul syllables
-                0xD7B0, 0xD7FF, // Hangul Jamo Extended-B
-                0xF900, 0xFAFF, // CJK compatibility ideographs
-                0xFE10, 0xFE6F, // CJK compatibility forms
-                0xFF00, 0xFFEF, // Halfwidth and Fullwidth Forms
-                0
-            ];
-            var rangeBytes = checked(glyphRanges.Length * sizeof(ushort));
-            _glyphRangesPtr = Marshal.AllocHGlobal(rangeBytes);
-            fixed (ushort* ranges = glyphRanges)
+            try
             {
-                Buffer.MemoryCopy(
-                    ranges,
-                    (void*)_glyphRangesPtr,
-                    rangeBytes,
-                    rangeBytes);
-            }
+                cfg->MergeMode = 1;
+                cfg->FontDataOwnedByAtlas = 0; // 自己管理内存，Build() 后释放
 
-            io.Fonts.AddFontFromMemoryTTF(_fontPtr1, ttf.Length, 16f, cfg, _glyphRangesPtr);
-            ImGuiNative.ImFontConfig_destroy(cfg);
+                ushort[] glyphRanges =
+                [
+                    // Latin, Greek, Cyrillic, punctuation, math and symbols.
+                    0x0020, 0x024F, 0x0250, 0x02FF,
+                    0x0300, 0x036F, 0x0370, 0x03FF,
+                    0x0400, 0x052F, 0x1100, 0x11FF,
+                    0x1AB0, 0x1AFF, 0x1C80, 0x1C8F,
+                    0x1CD0, 0x1CFF, 0x1DC0, 0x1DFF,
+                    0x1E00, 0x1EFF, 0x1F00, 0x1FFF,
+                    0x2C60, 0x2C7F,
+                    0x2DE0, 0x2DFF, 0xA640, 0xA69F,
+                    0xA720, 0xA7FF, 0xAB30, 0xAB6F,
+                    0x2000, 0x206F, 0x2070, 0x209F,
+                    0x20A0, 0x20CF, 0x2100, 0x214F,
+                    0x2150, 0x218F, 0x2190, 0x21FF,
+                    0x2200, 0x22FF, 0x2300, 0x23FF,
+                    0x2460, 0x24FF, 0x2500, 0x25FF,
+                    0x2600, 0x26FF, 0x2700, 0x27FF,
+                    0x2900, 0x29FF, 0x2A00, 0x2AFF,
+                    0x2B00, 0x2BFF,
+
+                    // CJK punctuation, Japanese, Korean, Chinese and fullwidth forms.
+                    0x2E80, 0x2FFF, 0x3000, 0x303F,
+                    0x3040, 0x30FF, 0x3100, 0x312F,
+                    0x3130, 0x318F, 0x3190, 0x31FF,
+                    0x3200, 0x33FF, 0x3400, 0x4DBF,
+                    0x4E00, 0x9FFF, 0xA960, 0xA97F,
+                    0xAC00, 0xD7FF, 0xF900, 0xFAFF,
+                    0xFB00, 0xFB4F, 0xFE10, 0xFE6F,
+                    0xFF00, 0xFFEF,
+                    0
+                ];
+                _glyphRangesPtr = CopyGlyphRanges(glyphRanges);
+                io.Fonts.AddFontFromMemoryTTF(_fontPtr1, ttf.Length, 16f, cfg, _glyphRangesPtr);
+            }
+            finally
+            {
+                ImGuiNative.ImFontConfig_destroy(cfg);
+            }
         }
         catch { /* 静默跳过 */ }
     }
@@ -116,14 +412,73 @@ public interface IImGuiRenderer
 
             // 基础字体：FontAwesome 7 图标
             var cfg = ImGuiNative.ImFontConfig_ImFontConfig();
-            cfg->FontDataOwnedByAtlas = 0; // 自己管理内存
+            try
+            {
+                cfg->FontDataOwnedByAtlas = 0; // 自己管理内存
 
-            ushort[] iconRange = [0xe005, 0xf8ff, 0];
-            fixed (ushort* r = iconRange)
-                io.Fonts.AddFontFromMemoryTTF(_fontPtr2, ttf.Length, 16f, cfg, (IntPtr)r);
-            ImGuiNative.ImFontConfig_destroy(cfg);
+                ushort[] iconRange = [0xe005, 0xf8ff, 0];
+                var iconRangePtr = CopyGlyphRanges(iconRange);
+                io.Fonts.AddFontFromMemoryTTF(_fontPtr2, ttf.Length, 16f, cfg, iconRangePtr);
+            }
+            finally
+            {
+                ImGuiNative.ImFontConfig_destroy(cfg);
+            }
         }
         catch { /* 静默跳过 */ }
+    }
+
+    private static unsafe void LoadAndroidFallbackFonts(ImGuiIOPtr io)
+    {
+        var loaded = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var spec in AndroidFallbackFonts)
+        {
+            var path = FindAndroidFont(spec.Names);
+            if (path == null || !loaded.Add(path))
+                continue;
+
+            try
+            {
+                var cfg = ImGuiNative.ImFontConfig_ImFontConfig();
+                try
+                {
+                    cfg->MergeMode = 1;
+                    cfg->FontDataOwnedByAtlas = 1;
+                    var rangePtr = CopyGlyphRanges(spec.Ranges);
+                    io.Fonts.AddFontFromFileTTF(path, 16f, cfg, rangePtr);
+                }
+                finally
+                {
+                    ImGuiNative.ImFontConfig_destroy(cfg);
+                }
+            }
+            catch
+            {
+                // Android vendors ship different subsets of the Noto family.
+                // A missing or unsupported fallback must not abort ImGui init.
+            }
+        }
+    }
+
+    private static string? FindAndroidFont(string[] names)
+    {
+        string[] roots =
+        [
+            "/system/fonts",
+            "/system_ext/fonts",
+            "/product/fonts",
+            "/vendor/fonts"
+        ];
+
+        foreach (var name in names)
+        foreach (var root in roots)
+        {
+            var path = Path.Combine(root, name);
+            if (File.Exists(path))
+                return path;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/StArray.ModManager/UI/IImGuiRenderer.cs
+++ b/StArray.ModManager/UI/IImGuiRenderer.cs
@@ -35,12 +35,13 @@ public interface IImGuiRenderer
         FreeFontMemory();
     }
 
-    private static nint _fontPtr1, _fontPtr2;
+    private static nint _fontPtr1, _fontPtr2, _glyphRangesPtr;
 
     private static void FreeFontMemory()
     {
         if (_fontPtr1 != 0) { Marshal.FreeHGlobal(_fontPtr1); _fontPtr1 = 0; }
         if (_fontPtr2 != 0) { Marshal.FreeHGlobal(_fontPtr2); _fontPtr2 = 0; }
+        if (_glyphRangesPtr != 0) { Marshal.FreeHGlobal(_glyphRangesPtr); _glyphRangesPtr = 0; }
     }
 
     private static unsafe void LoadEmbeddedFont(ImGuiIOPtr io)
@@ -57,13 +58,43 @@ public interface IImGuiRenderer
             _fontPtr1 = Marshal.AllocHGlobal(ttf.Length);
             Marshal.Copy(ttf, 0, _fontPtr1, ttf.Length);
 
-            // MergeMode: 中文字形合并到图标基础字体
+            // Merge the CJK font into the icon font. The range is kept in unmanaged
+            // memory until Build() because ImGui reads it while building the atlas.
             var cfg = ImGuiNative.ImFontConfig_ImFontConfig();
             cfg->MergeMode = 1;
             cfg->FontDataOwnedByAtlas = 0; // 自己管理内存，Build() 后释放
 
-            var glyphRanges = io.Fonts.GetGlyphRangesChineseSimplifiedCommon();
-            io.Fonts.AddFontFromMemoryTTF(_fontPtr1, ttf.Length, 16f, cfg, glyphRanges);
+            ushort[] glyphRanges =
+            [
+                0x0020, 0x00FF, // Basic Latin and Latin-1 Supplement
+                0x1100, 0x11FF, // Hangul Jamo
+                0x2000, 0x206F, // General Punctuation
+                0x2E80, 0x2FFF, // CJK radicals and ideographs
+                0x3000, 0x30FF, // CJK punctuation, Hiragana, Katakana
+                0x3100, 0x31FF, // Bopomofo and Hangul compatibility Jamo
+                0x3200, 0x33FF, // Enclosed CJK and compatibility characters
+                0x3400, 0x4DBF, // CJK Unified Ideographs Extension A
+                0x4E00, 0x9FFF, // CJK Unified Ideographs
+                0xA960, 0xA97F, // Hangul Jamo Extended-A
+                0xAC00, 0xD7A3, // Hangul syllables
+                0xD7B0, 0xD7FF, // Hangul Jamo Extended-B
+                0xF900, 0xFAFF, // CJK compatibility ideographs
+                0xFE10, 0xFE6F, // CJK compatibility forms
+                0xFF00, 0xFFEF, // Halfwidth and Fullwidth Forms
+                0
+            ];
+            var rangeBytes = checked(glyphRanges.Length * sizeof(ushort));
+            _glyphRangesPtr = Marshal.AllocHGlobal(rangeBytes);
+            fixed (ushort* ranges = glyphRanges)
+            {
+                Buffer.MemoryCopy(
+                    ranges,
+                    (void*)_glyphRangesPtr,
+                    rangeBytes,
+                    rangeBytes);
+            }
+
+            io.Fonts.AddFontFromMemoryTTF(_fontPtr1, ttf.Length, 16f, cfg, _glyphRangesPtr);
             ImGuiNative.ImFontConfig_destroy(cfg);
         }
         catch { /* 静默跳过 */ }


### PR DESCRIPTION
## Summary

修复 Android 端多个 Mod 使用同一 Native Hook 时互相覆盖、调用链断裂以及卸载后回调悬空导致崩溃的问题。

## Changes

- 新增 Android HookBroker：
  - 支持多个 Mod 对同一目标函数叠加 Hook。
  - 每层 Hook 都能通过 `Original` 继续调用下一层。
  - 记录 Hook owner、layer 数量，并复用重复注册的 detour。
  - 增加 AArch64 patch point 校验和错误诊断。
- Android Hook 链改为进程生命周期管理，避免直接移除根 Hook 破坏其他 Mod 的 continuation。
- 更新 Hook 生成器：
  - 生成持久化 dispatch wrapper，避免 Android 卸载 Mod 后 native 继续调用已释放 delegate。
  - 卸载时逻辑停用当前 Mod，并将调用转发到原函数/下一层 Hook。
  - 重新加载 Mod 时可以重新启用已有 Hook 层。
  - 多个 Hook 中任意一个安装失败或抛出异常时，自动回滚已安装的 Hook。
- 修复 `HookHelper.Instance` 为空时错误报告卸载成功的问题。
- 增加 Hook owner 作用域，便于区分不同 Mod 的 Hook 来源。
- 扩展 ImGui 字体 glyph range，支持中文、韩文以及相关 CJK 字符。

## Compatibility

- 本次修改仅针对 Android Hook 流程。
- Windows 专用 Hook 实现未修改。
- Android 的 Hook 层无法在进程运行期间安全地物理卸载，因此 `UninstallHooks()` 在 Android 上执行的是逻辑停用，并会保留必要的 delegate 和 continuation。

## Deployment Notes

必须将 APK 中的 `libmodmanager.so` 替换为本提交 Actions 生成的新版本，否则 HookBroker 和多 Mod Hook 支持不会生效。
