### PR TITLE
feat(android): support multiple mods sharing hooks in managed layer

### DIFF
--- a/StArray.ModManager.Android/Native/Dobby.cs
+++ b/StArray.ModManager.Android/Native/Dobby.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -14,6 +13,27 @@ namespace StArray.ModManager.Android.Native;
 public static class Dobby
 {
     private const string Lib = "modmanager";
+    private static readonly object HookLock = new();
+    private static readonly Dictionary<HookKey, HookRecord> InstalledHooks = new();
+    private static readonly Dictionary<nint, HookChain> HookChains = new();
+    private static readonly Dictionary<nint, nint> DetourTargets = new();
+    private static readonly Dictionary<nint, HookRecord> LatestHooks = new();
+
+    private readonly record struct HookKey(nint Target, nint Detour);
+
+    private sealed class HookChain(nint target)
+    {
+        public nint Target { get; } = target;
+        public nint Head { get; set; }
+        public List<HookRecord> Layers { get; } = new();
+    }
+
+    private sealed record HookRecord(
+        nint Target,
+        nint PatchPoint,
+        nint Detour,
+        nint Origin,
+        string Owner);
 
     // ========================================================================
     // Native externs
@@ -24,8 +44,116 @@ public static class Dobby
     /// <param name="replace">替换函数地址（nint 指向 delegate 或函数指针）</param>
     /// <param name="origin">[out] 原函数指针（用于调用原逻辑）</param>
     /// <returns>0 = 成功，非 0 = 失败</returns>
-    [DllImport(Lib, EntryPoint = "modmanager_dobby_hook")]
-    public static extern int Hook(nint address, nint replace, out nint origin);
+    [DllImport(Lib, EntryPoint = "modmanager_dobby_hook", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int InstallNativeHook(nint address, nint replace, out nint origin);
+
+    /// <summary>
+    /// 安装 inline hook，并保持旧版 API 兼容。
+    /// 同一目标的后续 detour 会安装到上一层 detour 上，形成托管侧维护的
+    /// Hook 链，不依赖新版本 native HookBroker 导出。
+    /// </summary>
+    public static int Hook(nint address, nint replace, out nint origin)
+        => Hook(address, replace, out origin, "Dobby.Hook");
+
+    /// <summary>安装带 owner 诊断信息的 Hook。</summary>
+    public static int Hook(nint address, nint replace, out nint origin, string? owner)
+    {
+        origin = nint.Zero;
+        if (address == nint.Zero || replace == nint.Zero)
+            return -1;
+        if (address == replace)
+            return -2;
+
+        lock (HookLock)
+        {
+            var key = new HookKey(address, replace);
+            if (InstalledHooks.TryGetValue(key, out var existing))
+            {
+                origin = existing.Origin;
+                return 0;
+            }
+
+            // A detour already used as another chain's layer is a patched
+            // entry point, not an independent target. Patching it as a new
+            // root would make the two managed registries disagree.
+            if (DetourTargets.ContainsKey(address))
+                return -3;
+
+            if (DetourTargets.TryGetValue(replace, out var boundTarget) &&
+                boundTarget != address)
+                return -3;
+
+            HookChains.TryGetValue(address, out var chain);
+            var patchPoint = chain?.Head ?? address;
+            if (patchPoint == nint.Zero || patchPoint == replace)
+                return -2;
+
+            var result = InstallNativeHook(patchPoint, replace, out origin);
+            if (result != 0)
+            {
+                origin = nint.Zero;
+                return result;
+            }
+
+            // A successful native hook must always provide a continuation. Do
+            // not publish an incomplete layer to the process-wide registry.
+            if (origin == nint.Zero)
+            {
+                RemoveNativeHook(patchPoint);
+                return -4;
+            }
+
+            chain ??= new HookChain(address);
+            if (!HookChains.ContainsKey(address))
+                HookChains.Add(address, chain);
+
+            var record = new HookRecord(
+                address,
+                patchPoint,
+                replace,
+                origin,
+                string.IsNullOrWhiteSpace(owner) ? "unknown" : owner);
+            chain.Head = replace;
+            chain.Layers.Add(record);
+            InstalledHooks[key] = record;
+            DetourTargets[replace] = address;
+            LatestHooks[address] = record;
+            return 0;
+        }
+    }
+
+    /// <summary>获取目标地址最近安装的 Hook 层，供诊断使用。</summary>
+    public static bool TryGetInstalledHook(
+        nint address,
+        out string owner,
+        out nint detour,
+        out nint origin)
+    {
+        lock (HookLock)
+        {
+            if (LatestHooks.TryGetValue(address, out var existing))
+            {
+                owner = existing.Owner;
+                detour = existing.Detour;
+                origin = existing.Origin;
+                return true;
+            }
+        }
+
+        owner = string.Empty;
+        detour = nint.Zero;
+        origin = nint.Zero;
+        return false;
+    }
+
+    /// <summary>获取 C# Hook 链的层数。</summary>
+    public static int GetLayerCount(nint address)
+    {
+        lock (HookLock)
+            return HookChains.TryGetValue(address, out var chain)
+                ? chain.Layers.Count
+                : 0;
+    }
 
     /// <summary>
     /// 安装 inline hook — 传入 C# Reflection MethodInfo。
@@ -45,7 +173,10 @@ public static class Dobby
         // 强制 JIT 编译该方法
         RuntimeHelpers.PrepareMethod(replaceMethod.MethodHandle);
         nint replacePtr = replaceMethod.MethodHandle.GetFunctionPointer();
-        return Hook(address, replacePtr, out origin);
+        var owner = replaceMethod.DeclaringType == null
+            ? replaceMethod.Name
+            : replaceMethod.DeclaringType.FullName + "." + replaceMethod.Name;
+        return Hook(address, replacePtr, out origin, owner);
     }
 
     /// <summary>安装动态指令插桩。</summary>
@@ -58,8 +189,41 @@ public static class Dobby
     /// <summary>移除 hook 并恢复原函数。</summary>
     /// <param name="address">被 hook 的函数地址</param>
     /// <returns>0 = 成功</returns>
-    [DllImport(Lib, EntryPoint = "modmanager_dobby_destroy")]
-    public static extern int Destroy(nint address);
+    [DllImport(Lib, EntryPoint = "modmanager_dobby_destroy", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int RemoveNativeHook(nint address);
+
+    /// <summary>
+    /// 移除单层 Hook。包含多层的链不能安全地从中间拆除，因此保留到进程结束。
+    /// </summary>
+    public static int Destroy(nint address)
+    {
+        lock (HookLock)
+        {
+            if (HookChains.TryGetValue(address, out var chain) && chain.Layers.Count > 1)
+                return -5;
+            if (DetourTargets.ContainsKey(address))
+                return -5;
+
+            // Keep the native operation inside the same lock as registry
+            // updates so a concurrent install cannot attach to a hook while
+            // it is being restored.
+            var result = RemoveNativeHook(address);
+            if (result != 0)
+                return result;
+
+            if (!HookChains.Remove(address, out var removedChain))
+                return result;
+
+            foreach (var layer in removedChain.Layers)
+            {
+                InstalledHooks.Remove(new HookKey(layer.Target, layer.Detour));
+                DetourTargets.Remove(layer.Detour);
+            }
+            LatestHooks.Remove(address);
+
+            return result;
+        }
+    }
 
     /// <summary>按动态库名和符号名解析函数地址。</summary>
     /// <param name="imageName">动态库名，如 "libil2cpp.so"</param>


### PR DESCRIPTION
## Summary

在 Android C# 层实现多 Mod 共享同一 Native Hook，避免依赖新版 native HookBroker，也无需修改或替换 APK 中的 `libmodmanager.so`。

## Changes

- 在 `Dobby.Hook` 外层增加托管 Hook 链管理。
- 支持多个 Mod 对同一个目标函数依次安装 Hook。
- 后安装的 Hook 会连接到上一层 detour。
- 保持每层 Hook 的 `origin` continuation，使 Mod 可以继续调用下一层 Hook 或原函数。
- 重复注册相同的目标地址和 detour 时复用已有 Hook。
- 增加 Hook 链、层数、owner 和 detour 目标的记录。
- 增加线程锁，避免并发安装 Hook 时破坏链状态。
- 增加目标地址、detour 地址和 continuation 指针校验。
- Native Hook 安装成功但未返回有效 continuation 时自动回滚。
- 保持原有 `Dobby.Hook` API 兼容，并为反射方式安装的 Hook 自动记录 owner。
- 明确指定 Android native 调用使用 `Cdecl` 调用约定。
- 多层 Hook 存在时不再物理移除 Hook，避免破坏其他 Mod 的 continuation。

## Compatibility

- 仅修改 Android C# 层。
- 未修改 Windows 代码。
- 未修改 native Hook 实现。
- 不需要替换 APK 中已有的 `libmodmanager.so`。
- 兼容现有使用 `Dobby.Hook` 的 Mod，前提是 Mod 通过 Mod Manager 提供的托管 API 安装 Hook。
- 单层 Hook 仍可使用原有的 `Dobby.Destroy`。

## Behavior

同一目标函数的 Hook 链如下：

```text
原函数
  ^
Hook A Original
  ^
Hook B Original
  ^
游戏调用入口
